### PR TITLE
[CI][Docs] Clarify docker compose image usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
 version: "3.8"
 services:
   oel:
-    # To build the 'oel' image locally, run: docker build -t oel . (assuming Dockerfile is in the project root)
-    image: oel
+    # Before running `docker compose up`, either load the prebuilt tarball:
+    #   docker load < oferta-laboral.tar.gz
+    # or build the image locally:
+    #   docker compose build oel
+    image: oferta-laboral:latest
+    build: .
     command: bash
     volumes:
       - ./data:/data

--- a/docs/containers/MAINTAINER_GUIDE.md
+++ b/docs/containers/MAINTAINER_GUIDE.md
@@ -5,13 +5,11 @@ This document describes how to manage container images for the project.
 ## Update dependencies
 
 1. Edit [`environment.yml`](../../environment.yml) when dependencies change.
-2. Rebuild the development image and push it to GHCR (authenticate with a token that has `write:packages` scope):
-   > **Note:** Replace `{YOUR_GITHUB_USERNAME}` with your actual GitHub username or organization name in the commands below.
+2. Rebuild the development image and save it as a tarball for distribution:
    ```bash
-   docker build -t ghcr.io/{YOUR_GITHUB_USERNAME}/oferta_educativa_laboral:dev .
-   docker push ghcr.io/{YOUR_GITHUB_USERNAME}/oferta_educativa_laboral:dev
+   docker build -t oferta-laboral:dev .
+   docker save oferta-laboral:dev | gzip > oferta-laboral-dev.tar.gz
    ```
-3. The workflow [`docker-build.yml`](../../.github/workflows/docker-build.yml) builds the image in CI and pushes it to GHCR using the `GHCR_TOKEN` secret. Ensure this secret is defined in the repository settings with appropriate scopes.
 
 ## Build Apptainer images
 
@@ -20,12 +18,12 @@ This document describes how to manage container images for the project.
   apptainer build oferta-laboral.sif Singularity.def
   ```
 - **CI build**
-  The workflow [`singularity-build.yml`](../../.github/workflows/singularity-build.yml) performs the same step in GitHub Actions and also requires `GHCR_TOKEN` for authentication.
+  The workflow [`singularity-build.yml`](../../.github/workflows/singularity-build.yml) performs the same step in GitHub Actions.
 
 ## Testing
 
 Before publishing any image, run the project tests inside the container to ensure the environment works as expected. For example:
 
 ```bash
-docker run --rm ghcr.io/{GITHUB_ORG_OR_USERNAME}/oferta_educativa_laboral:dev pytest --maxfail=1 --disable-warnings -q
+docker run --rm oferta-laboral:dev pytest --maxfail=1 --disable-warnings -q
 ```

--- a/docs/containers/USER_GUIDE.md
+++ b/docs/containers/USER_GUIDE.md
@@ -1,16 +1,21 @@
 # Container User Guide
 
-This guide shows how to run the pipeline using the prebuilt image from the GitHub Container Registry (GHCR) and how to convert that image to Apptainer for high-performance computing (HPC) environments.
+This guide shows how to run the pipeline using a prebuilt Docker image distributed as a tarball or by building the image locally. It also covers converting the image to Apptainer for high-performance computing (HPC) environments.
 
 ## Using Docker
 
-Pull the image from GHCR and execute the pipeline:
+Load the prebuilt image tarball and execute the pipeline:
 
-> **Important:** Replace `<owner>` in the commands below with the GitHub organization or username that hosts the image. For example, if your organization is `acme-corp`, use `ghcr.io/acme-corp/oferta_educativa_laboral:latest`.
 ```bash
-docker pull ghcr.io/<owner>/oferta_educativa_laboral:latest
-docker run --rm -v "$PWD/data:/data" ghcr.io/<owner>/oferta_educativa_laboral:latest \
+docker load < oferta-laboral.tar.gz
+docker run --rm -v "$PWD/data:/data" oferta-laboral:latest \
     python oferta_educativa_laboral/pipeline/pipeline_oferta_laboral.py make full -v5
+```
+
+If you do not have the tarball, build the image locally:
+
+```bash
+docker build -t oferta-laboral:latest .
 ```
 
 - `-v "$PWD/data:/data"` mounts a host `data` directory inside the container.
@@ -19,11 +24,10 @@ docker run --rm -v "$PWD/data:/data" ghcr.io/<owner>/oferta_educativa_laboral:la
 
 ## Using Apptainer (rootless HPC)
 
-Build an Apptainer image from the GHCR image and run the pipeline:
+Build an Apptainer image from the repository's `Singularity.def` and run the pipeline:
 
-**Remember to replace `<owner>` with your GitHub organization or username as described above.**
 ```bash
-apptainer build oferta-laboral.sif docker://ghcr.io/<owner>/oferta_educativa_laboral:latest
+apptainer build oferta-laboral.sif Singularity.def
 apptainer run --bind "$PWD/data:/data" oferta-laboral.sif \
     python oferta_educativa_laboral/pipeline/pipeline_oferta_laboral.py make full -v5
 ```


### PR DESCRIPTION
## Summary
- load a tarball or build the image locally before running Docker Compose
- document tarball workflow for users and maintainers

## Testing
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*
- `make build` *(fails: No rule to make target 'build')*
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'docopt')*
- `coverage run -m pytest && coverage report` *(fails: command not found: coverage)*
- `Rscript -e "devtools::test(reporter = 'summary')"` *(fails: command not found: Rscript)*
- `Rscript -e "covr::report()"` *(fails: command not found: Rscript)*
- `shellcheck bash/*.sh` *(fails: command not found: shellcheck)*
- `bats tests/bash` *(fails: command not found: bats)*
- `sphinx-build docs/ docs/_build/html` *(fails: command not found: sphinx-build)*

------
https://chatgpt.com/codex/tasks/task_e_6893c75c3fc083268395ddfb59558aea